### PR TITLE
On MacOSX, use Applescript to force the editor to the foreground

### DIFF
--- a/notepad.tcl
+++ b/notepad.tcl
@@ -309,6 +309,13 @@ proc main {filename} {
     }
     focus -force $app.f.txt
     wm deiconify $app
+    if {[tk windowingsystem] eq "aqua"} {
+        exec /usr/bin/osascript -e {
+            tell app "Finder"
+                set frontmost of process "Wish" to true
+            end tell
+        }
+    }
     tkwait window $app
 }
 


### PR DESCRIPTION
Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
