### PR TITLE
Whitespace and column limit marker.

### DIFF
--- a/notepad.tcl
+++ b/notepad.tcl
@@ -320,24 +320,11 @@ proc main {filename} {
     grid columnconfigure $app 0 -weight 1
     grid rowconfigure $app 0 -weight 1
 
-    if {[info commands tk::_TextSetCursor] eq {}} {
-        # override key handling to update the statusbar position field.
-        rename tk::TextSetCursor tk::_TextSetCursor
-        proc tk::TextSetCursor {w pos} {
-            set top [winfo toplevel $w]
-            if {[winfo class $top] eq "Notepad"} {
-                UpdateStatusPos $top $pos
-            }
-            return [tk::_TextSetCursor $w $pos]
-        }
-        # update the statusbar position on mouse clicks.
-        bind $app.f.txt <ButtonRelease-1> {+UpdateStatusPos [winfo toplevel %W] insert}
-        bind $app.f.txt <ButtonPress-1> {+UpdateStatusPos [winfo toplevel %W] [%W index @%x,%y]}
-    }
-
-    bind $app <Key> {+UpdateStatusPos [winfo toplevel %W] insert}
+    bind $app.f.txt <ButtonRelease-1> {+UpdateStatusPos [winfo toplevel %W] insert}
+    bind $app.f.txt <ButtonPress-1> {+UpdateStatusPos [winfo toplevel %W] [%W index @%x,%y]}
     bind $app.f.txt <Key-space> {OnKeyWhitespace %W %A; break}
     bind $app.f.txt <Key-Tab> {OnKeyWhitespace %W %A; break}
+    bind $app <Key> {+UpdateStatusPos [winfo toplevel %W] insert}
 
     if {[tk windowingsystem] eq "win32"} {bind $app <Control-F2> {console show}}
     bind $app <Control-o> [list Open $app]

--- a/notepad.tcl
+++ b/notepad.tcl
@@ -299,7 +299,7 @@ proc main {filename} {
         bind $app.f.txt <ButtonPress-1> {+UpdateStatusPos [winfo toplevel %W] [%W index @%x,%y]}
     }
 
-    bind $app <Control-F2> {console show}
+    if {[tk windowingsystem] eq "win32"} {bind $app <Control-F2> {console show}}
     bind $app <Control-o> [list Open $app]
     bind $app <Control-s> [list Save $app]
     bind $app <Control-S> [list SaveAs $app]


### PR DESCRIPTION
This adds support for displaying whitespace visibly (spaces become center-dot and tabs become visible arrows) and a marker for column 76. These are off by default but can be enabled via the menu or command line options.
This should help with issue #2.
